### PR TITLE
only fail melt for failed status check

### DIFF
--- a/mint/lightning/lightning.go
+++ b/mint/lightning/lightning.go
@@ -29,6 +29,7 @@ const (
 )
 
 type PaymentStatus struct {
-	Preimage      string
-	PaymentStatus State
+	Preimage             string
+	PaymentStatus        State
+	PaymentFailureReason string
 }

--- a/mint/lightning/lnd.go
+++ b/mint/lightning/lnd.go
@@ -146,14 +146,12 @@ func (lnd *LndClient) OutgoingPaymentStatus(ctx context.Context, hash string) (P
 	if err != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) ||
 			strings.Contains(err.Error(), "context deadline exceeded") {
-
 			return PaymentStatus{PaymentStatus: Pending}, nil
 		}
-		return PaymentStatus{PaymentStatus: Failed}, fmt.Errorf("payment failed: %w", err)
+		return PaymentStatus{PaymentStatus: Failed}, err
 	}
 	if payment.Status == lnrpc.Payment_UNKNOWN || payment.Status == lnrpc.Payment_FAILED {
-		return PaymentStatus{PaymentStatus: Failed},
-			fmt.Errorf("payment failed: %s", payment.FailureReason.String())
+		return PaymentStatus{PaymentStatus: Failed, PaymentFailureReason: payment.FailureReason.String()}, nil
 	}
 	if payment.Status == lnrpc.Payment_IN_FLIGHT {
 		return PaymentStatus{PaymentStatus: Pending}, nil

--- a/mint/server.go
+++ b/mint/server.go
@@ -399,7 +399,7 @@ func (ms *MintServer) meltQuoteState(rw http.ResponseWriter, req *http.Request) 
 	method := vars["method"]
 	quoteId := vars["quote_id"]
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
 	meltQuote, err := ms.mint.GetMeltQuoteState(ctx, method, quoteId)


### PR DESCRIPTION
do not set melt quote to unpaid unless it successfully checked the status of the payment with the lightning backend and the status was a failed payment.