### PR TITLE
README: fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Implemented [NUTs](https://github.com/cashubtc/nuts/):
 With [Go](https://go.dev/doc/install) installed, you can run the following command to install the wallet:
 
 ```
-go install github.com/elnosh/gonuts/cmd/nutw@latest
+git clone https://github.com/elnosh/gonuts
+cd gonuts
+go install ./cmd/nutw/
 ```
 
 To setup a mint for the wallet, create a `.env` file at ~/.gonuts/wallet/.env and setup your preferred mint.


### PR DESCRIPTION
Direct installatino with `go install <pkg-path>` is not working, because replaces are used in go.mod file and [Go doesn't support this](https://github.com/golang/go/issues/44840).

```
$ go install github.com/elnosh/gonuts/cmd/nutw@latest go: downloading github.com/elnosh/gonuts v0.2.0
go: github.com/elnosh/gonuts/cmd/nutw@latest (in github.com/elnosh/gonuts@v0.2.0):
        The go.mod file for the module providing named packages contains one or
        more replace directives. It must not contain directives that would cause
        it to be interpreted differently than if it were the main module.
```