### PR TITLE
wallet: identify lightning payment failed in melt

### DIFF
--- a/cashu/cashu.go
+++ b/cashu/cashu.go
@@ -475,10 +475,10 @@ const (
 	MintingDisabledErrCode         CashuErrCode = 20003
 	MintQuoteInvalidSigErrCode     CashuErrCode = 20008
 
+	LightningPaymentErrCode     CashuErrCode = 20004
 	MeltQuotePendingErrCode     CashuErrCode = 20005
 	MeltQuoteAlreadyPaidErrCode CashuErrCode = 20006
 
-	//LightningPaymentErrCode     CashuErrCode = 20008
 	MeltQuoteErrCode CashuErrCode = 20009
 )
 
@@ -503,6 +503,7 @@ var (
 	DuplicateProofs              = Error{Detail: "duplicate proofs", Code: InvalidProofErrCode}
 	QuoteNotExistErr             = Error{Detail: "quote does not exist", Code: MeltQuoteErrCode}
 	QuotePending                 = Error{Detail: "quote is pending", Code: MeltQuotePendingErrCode}
+	LightningPaymentFailed       = Error{Detail: "Lightning payment failed", Code: LightningPaymentErrCode}
 	MeltQuoteAlreadyPaid         = Error{Detail: "quote already paid", Code: MeltQuoteAlreadyPaidErrCode}
 	MeltAmountExceededErr        = Error{Detail: "max amount for melting exceeded", Code: AmountLimitExceeded}
 	MeltQuoteForRequestExists    = Error{Detail: "melt quote for payment request already exists", Code: MeltQuoteErrCode}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -913,14 +913,22 @@ func (w *Wallet) Melt(quoteId string) (*nut05.PostMeltQuoteBolt11Response, error
 	}
 	meltBolt11Response, err := client.PostMeltBolt11(mint.mintURL, meltBolt11Request)
 	if err != nil {
-		// if there was error with melt, remove proofs from pending and save them for use
-		if err := w.db.SaveProofs(proofs); err != nil {
-			return nil, fmt.Errorf("error storing proofs: %v", err)
+		if cashuErr, ok := err.(cashu.Error); ok {
+			if cashuErr.Code == cashu.LightningPaymentErrCode {
+				// only remove proofs from pending and save them for use
+				// if got specific error that payment failed
+				if err := w.db.SaveProofs(proofs); err != nil {
+					return nil, fmt.Errorf("error storing proofs: %v", err)
+				}
+				if err := w.db.DeletePendingProofsByQuoteId(quote.QuoteId); err != nil {
+					return nil, fmt.Errorf("error removing pending proofs: %v", err)
+				}
+				return nil, err
+			}
+		} else {
+			// for any other errors leave proofs as pending
+			return nil, fmt.Errorf("error doing melt request: %v. Proofs are pending", err)
 		}
-		if err := w.db.DeletePendingProofsByQuoteId(quote.QuoteId); err != nil {
-			return nil, fmt.Errorf("error removing pending proofs: %v", err)
-		}
-		return nil, err
 	}
 
 	switch meltBolt11Response.State {


### PR DESCRIPTION
use error code to identify failed lightning payment failed in a melt request. If confirmed that the payment failed, then set proofs to be used for other ops. If any other error during melt, leave proofs as pending. Can further check status of pending proofs or quote with `CheckMeltQuoteState`.