### PR TITLE
mint - duplicate inputs and outputs error codes

### DIFF
--- a/cashu/cashu.go
+++ b/cashu/cashu.go
@@ -492,18 +492,20 @@ const (
 	DBErrCode               CashuErrCode = 1
 	LightningBackendErrCode CashuErrCode = 2
 
-	UnitErrCode                        CashuErrCode = 11005
-	PaymentMethodErrCode               CashuErrCode = 11007
 	BlindedMessageAlreadySignedErrCode CashuErrCode = 10002
+	InvalidProofErrCode                CashuErrCode = 10003
 
-	InvalidProofErrCode            CashuErrCode = 10003
 	ProofAlreadyUsedErrCode        CashuErrCode = 11001
 	InsufficientProofAmountErrCode CashuErrCode = 11002
+	PaymentMethodErrCode           CashuErrCode = 11003
+	UnitErrCode                    CashuErrCode = 11005
+	AmountLimitExceeded            CashuErrCode = 11006
+	DuplicateInputErrCode          CashuErrCode = 11007
+	DuplicateOutputErrCode         CashuErrCode = 11008
 
 	UnknownKeysetErrCode  CashuErrCode = 12001
 	InactiveKeysetErrCode CashuErrCode = 12002
 
-	AmountLimitExceeded            CashuErrCode = 11006
 	MintQuoteRequestNotPaidErrCode CashuErrCode = 20001
 	MintQuoteAlreadyIssuedErrCode  CashuErrCode = 20002
 	MintingDisabledErrCode         CashuErrCode = 20003
@@ -535,7 +537,8 @@ var (
 	ProofPendingErr              = Error{Detail: "proof is pending", Code: ProofAlreadyUsedErrCode}
 	InvalidProofErr              = Error{Detail: "invalid proof", Code: InvalidProofErrCode}
 	NoProofsProvided             = Error{Detail: "no proofs provided", Code: InvalidProofErrCode}
-	DuplicateProofs              = Error{Detail: "duplicate proofs", Code: InvalidProofErrCode}
+	DuplicateProofs              = Error{Detail: "duplicate inputs", Code: DuplicateInputErrCode}
+	DuplicateOutputs             = Error{Detail: "duplicate outputs", Code: DuplicateOutputErrCode}
 	QuoteNotExistErr             = Error{Detail: "quote does not exist", Code: MeltQuoteErrCode}
 	QuotePending                 = Error{Detail: "quote is pending", Code: MeltQuotePendingErrCode}
 	LightningPaymentFailed       = Error{Detail: "Lightning payment failed", Code: LightningPaymentErrCode}
@@ -571,6 +574,20 @@ func CheckDuplicateProofs(proofs Proofs) bool {
 			return true
 		} else {
 			proofsMap[proof] = true
+		}
+	}
+
+	return false
+}
+
+func CheckDuplicateBlindedMessages(bms BlindedMessages) bool {
+	bmMap := make(map[BlindedMessage]bool)
+
+	for _, bm := range bms {
+		if bmMap[bm] {
+			return true
+		} else {
+			bmMap[bm] = true
 		}
 	}
 

--- a/mint/mint.go
+++ b/mint/mint.go
@@ -404,6 +404,10 @@ func (m *Mint) MintTokens(mintTokensRequest nut04.PostMintBolt11Request) (cashu.
 				return cashu.InvalidBlindedMessageAmount
 			}
 
+			if cashu.CheckDuplicateBlindedMessages(blindedMessages) {
+				return cashu.DuplicateOutputs
+			}
+
 			// verify that amount from blinded messages is enough
 			// for quote amount
 			if blindedMessagesAmount > mintQuote.Amount {
@@ -505,6 +509,10 @@ func (m *Mint) Swap(proofs cashu.Proofs, blindedMessages cashu.BlindedMessages) 
 	blindedMessagesAmount, err := blindedMessages.AmountChecked()
 	if err != nil {
 		return nil, cashu.InvalidBlindedMessageAmount
+	}
+
+	if cashu.CheckDuplicateBlindedMessages(blindedMessages) {
+		return nil, cashu.DuplicateOutputs
 	}
 
 	B_s := make([]string, len(blindedMessages))

--- a/mint/mint_integration_test.go
+++ b/mint/mint_integration_test.go
@@ -260,6 +260,17 @@ func TestMintTokens(t *testing.T) {
 		t.Fatalf("expected error '%v' but got '%v' instead", cashu.InvalidBlindedMessageAmount, err)
 	}
 
+	// test duplicate blinded messages in request
+	bmLen := len(blindedMessages)
+	duplicateBlindedMessages := make(cashu.BlindedMessages, bmLen)
+	copy(duplicateBlindedMessages, blindedMessages)
+	duplicateBlindedMessages[bmLen-2] = duplicateBlindedMessages[bmLen-1]
+	mintTokensRequest = nut04.PostMintBolt11Request{Quote: mintQuoteResponse.Id, Outputs: duplicateBlindedMessages}
+	_, err = testMint.MintTokens(mintTokensRequest)
+	if !errors.Is(err, cashu.DuplicateOutputs) {
+		t.Fatalf("expected error '%v' but got '%v' instead", cashu.DuplicateOutputs, err)
+	}
+
 	// valid mint request
 	mintTokensRequest = nut04.PostMintBolt11Request{Quote: mintQuoteResponse.Id, Outputs: blindedMessages}
 	_, err = testMint.MintTokens(mintTokensRequest)
@@ -373,6 +384,16 @@ func TestSwap(t *testing.T) {
 	_, err = testMint.Swap(proofs, overflowBlindedMessages)
 	if !errors.Is(err, cashu.InvalidBlindedMessageAmount) {
 		t.Fatalf("expected error '%v' but got '%v' instead", cashu.InvalidBlindedMessageAmount, err)
+	}
+
+	// test duplicate blinded messages in request
+	bmLen := len(newBlindedMessages)
+	duplicateBlindedMessages := make(cashu.BlindedMessages, bmLen)
+	copy(duplicateBlindedMessages, newBlindedMessages)
+	duplicateBlindedMessages[bmLen-2] = duplicateBlindedMessages[bmLen-1]
+	_, err = testMint.Swap(proofs, duplicateBlindedMessages)
+	if !errors.Is(err, cashu.DuplicateOutputs) {
+		t.Fatalf("expected error '%v' but got '%v' instead", cashu.DuplicateOutputs, err)
 	}
 
 	// test with duplicates in proofs list passed

--- a/mint/storage/sqlite/sqlite_test.go
+++ b/mint/storage/sqlite/sqlite_test.go
@@ -340,24 +340,8 @@ func TestBlindSignatures(t *testing.T) {
 	blindedMessages := generateRandomB_s(count)
 	blindSignatures := generateBlindSignatures(count)
 
-	var wg sync.WaitGroup
-	var mu sync.RWMutex
-	errs := make([]error, 0)
-	for i := 0; i < count; i++ {
-		wg.Add(1)
-		go func() {
-			if err := db.SaveBlindSignature(blindedMessages[i], blindSignatures[i]); err != nil {
-				mu.Lock()
-				errs = append(errs, err)
-				mu.Unlock()
-			}
-			wg.Done()
-		}()
-	}
-	wg.Wait()
-
-	if len(errs) > 0 {
-		t.Fatalf("error saving blind signature: %v", errs[0])
+	if err := db.SaveBlindSignatures(blindedMessages, blindSignatures); err != nil {
+		t.Fatalf("unexpected error saving blind signatures: %v", err)
 	}
 
 	expectedBlindSig := blindSignatures[21]

--- a/mint/storage/storage.go
+++ b/mint/storage/storage.go
@@ -35,7 +35,7 @@ type MintDB interface {
 	GetMeltQuoteByPaymentRequest(string) (*MeltQuote, error)
 	UpdateMeltQuote(quoteId string, preimage string, state nut05.State) error
 
-	SaveBlindSignature(B_ string, blindSignature cashu.BlindedSignature) error
+	SaveBlindSignatures(B_s []string, blindSignatures cashu.BlindedSignatures) error
 	GetBlindSignature(B_ string) (cashu.BlindedSignature, error)
 	GetBlindSignatures(B_s []string) (cashu.BlindedSignatures, error)
 


### PR DESCRIPTION
- save blind signatures in one tx
- use error codes for duplicate inputs and outputs from here: https://github.com/cashubtc/nuts/pull/223