### PR TITLE
fix: correct integer comparison

### DIFF
--- a/cashu/nuts/nut13/nut13.go
+++ b/cashu/nuts/nut13/nut13.go
@@ -122,7 +122,7 @@ func CheckCollidingKeysets(currentKeysetIds []string, newMintKeysetIds []string)
 
 		for j := range newMintKeysetIds {
 			if currentKeysetIds[i] == newMintKeysetIds[j] {
-				return fmt.Errorf("%w. KeysetId: %+v", ErrCollidingKeysetId, currentKeysetIds[i])
+				return fmt.Errorf("%w. KeysetId: %+v. New KeysetId: %+v", ErrCollidingKeysetId, currentKeysetIds[i], newMintKeysetIds[j])
 			}
 
 			keysetIdIntToCompare, err := keysetIdToBigInt(newMintKeysetIds[j])
@@ -130,8 +130,8 @@ func CheckCollidingKeysets(currentKeysetIds []string, newMintKeysetIds []string)
 				return err
 			}
 
-			if keysetIdInt == keysetIdIntToCompare {
-				return fmt.Errorf("%w. KeysetId: %+v", ErrCollidingKeysetId, currentKeysetIds[i])
+			if keysetIdInt.Cmp(keysetIdIntToCompare) == 0 {
+				return fmt.Errorf("%w. KeysetId: %+v. New KeysetId: %+v", ErrCollidingKeysetId, currentKeysetIds[i], newMintKeysetIds[j])
 			}
 		}
 	}

--- a/cashu/nuts/nut13/nut13_test.go
+++ b/cashu/nuts/nut13/nut13_test.go
@@ -85,6 +85,7 @@ func TestCollisionOfIdNoCollision(t *testing.T) {
 		t.Errorf("There should not have been any keyset collision")
 	}
 }
+
 func TestCollisionOfIdWithCollision(t *testing.T) {
 	keysetId := []string{"009a1f293253e41e", "009a1f293253e41d"}
 
@@ -94,5 +95,16 @@ func TestCollisionOfIdWithCollision(t *testing.T) {
 
 	if !errors.Is(err, ErrCollidingKeysetId) {
 		t.Errorf("there should have been a keyset collition error")
+	}
+}
+
+func TestCollitionForIntegerValues(t *testing.T) {
+	currentKeysetIds := []string{"00682d5c11e19b7c"}
+	newKeysetIds := []string{"0059051691ffec07"}
+
+	err := CheckCollidingKeysets(currentKeysetIds, newKeysetIds)
+
+	if !errors.Is(err, ErrCollidingKeysetId) {
+		t.Errorf("there should have been a keyset collition error based on the big int value")
 	}
 }


### PR DESCRIPTION
Fix the integer representation compare values. Before it was just comparing memory addresses this is clearly wrong